### PR TITLE
Add basic encounter creation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.idea/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.0'
 
-
+gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,26 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.1.6)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
 
 RUBY VERSION
    ruby 2.5.0p0

--- a/manage_encounter.rb
+++ b/manage_encounter.rb
@@ -56,7 +56,7 @@ def request_monster_race
   message << " (Default #{default_race})" if default_race.present?
 
   puts message
-  gets.chomp
+  gets.chomp.presence || default_race
 end
 
 def request_monster_max_health(message = 'Max Health:')

--- a/manage_encounter.rb
+++ b/manage_encounter.rb
@@ -1,3 +1,5 @@
+# TODO: Refactor Encounter and Monster to adopt some of this logic.
+
 require 'active_support/core_ext/string'
 require 'json'
 
@@ -73,13 +75,31 @@ def request_new_monster_data
   monster_name = request_monster_name
   monster_race = request_monster_race
   monster_max_health = request_monster_max_health
+
   { name: monster_name, race: monster_race, max_health: monster_max_health }
 end
 
+def user_accepts_continue_prompt?
+  puts 'Continue?'
+  response = gets.chomp.downcase
+
+  affirmative_responses = %w[y yes yeah sure ok]
+  affirmative_responses.include? response
+end
+
+# Request and Set Encounter Name
 encounter_name = request_encounter_name
 @encounter_data[:name] = encounter_name
 
+# Request and Set Info for First Monster
 monster_data = request_new_monster_data
 @encounter_data[:monsters] << monster_data
 
+# Request and Set Info for Additional Monsters
+while user_accepts_continue_prompt?
+  monster_data = request_new_monster_data
+  @encounter_data[:monsters] << monster_data
+end
+
+# Write Data to the Encounter File
 write_encounter_file(@encounter_data)

--- a/manage_encounter.rb
+++ b/manage_encounter.rb
@@ -1,21 +1,40 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/string'
 require 'json'
 
 SAFE_FILENAME_CHARACTERS = /[\w-]/.freeze
 ENCOUNTERS_DIRECTORY = 'data/encounters'
 
-def sanitize_filename(filename, extension:)
-  filename = filename.downcase.gsub(' ', '-')
-  sanitized_filename = filename.scan(SAFE_FILENAME_CHARACTERS).join
-  "#{sanitized_filename}.#{extension}"
+def sanitize_filename(base_name, extension: nil)
+  base_name = base_name.downcase.gsub(' ', '-')
+  sanitized_filename = base_name.scan(SAFE_FILENAME_CHARACTERS).join
+
+  return unless sanitized_filename.present?
+  sanitized_filename << ".#{extension}" if extension.present?
+  puts ''
+
+  sanitized_filename
 end
 
-# Ask for encounter name
-puts 'Encounter Name:'
-encounter_name = gets.chomp
+def encounter_name_valid? encounter_name
+  sanitized_name = sanitize_filename(encounter_name)
+  sanitized_name.present?
+end
 
-# Assemble encounter data
+def request_encounter_name(message)
+  puts message
+  encounter_name = gets.chomp
+
+  if encounter_name_valid? encounter_name
+    encounter_name
+  else
+    request_encounter_name('Invalid encounter name. Please try again.')
+  end
+end
+
+# Collect encounter data
+encounter_name = request_encounter_name('Encounter Name:')
 encounter_data = { name: encounter_name }
 
 # Create JSON file

--- a/manage_encounter.rb
+++ b/manage_encounter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'json'
+
+SAFE_FILENAME_CHARACTERS = /[\w-]/.freeze
+ENCOUNTERS_DIRECTORY = 'data/encounters'
+
+def sanitize_filename(filename, extension:)
+  filename = filename.downcase.gsub(' ', '-')
+  sanitized_filename = filename.scan(SAFE_FILENAME_CHARACTERS).join
+  "#{sanitized_filename}.#{extension}"
+end
+
+# Ask for encounter name
+puts 'Encounter Name:'
+encounter_name = gets.chomp
+
+# Assemble encounter data
+encounter_data = { name: encounter_name }
+
+# Create JSON file
+encounter_filename = sanitize_filename(encounter_name, extension: 'json')
+encounter_file_destination = "#{ENCOUNTERS_DIRECTORY}/#{encounter_filename}"
+File.write(encounter_file_destination, encounter_data.to_json)
+
+puts encounter_filename

--- a/manage_encounter.rb
+++ b/manage_encounter.rb
@@ -6,6 +6,15 @@ require 'json'
 SAFE_FILENAME_CHARACTERS = /[\w-]/.freeze
 ENCOUNTERS_DIRECTORY = 'data/encounters'
 
+def write_encounter_file(encounter_data)
+  encounter_name = encounter_data[:name]
+  encounter_filename = sanitize_filename(encounter_name, extension: 'json')
+  encounter_file_destination = "#{ENCOUNTERS_DIRECTORY}/#{encounter_filename}"
+  File.write(encounter_file_destination, encounter_data.to_json)
+
+  puts "Printed encounter info to #{encounter_file_destination}"
+end
+
 def sanitize_filename(base_name, extension: nil)
   base_name = base_name.downcase.gsub(' ', '-')
   sanitized_filename = base_name.scan(SAFE_FILENAME_CHARACTERS).join
@@ -33,13 +42,6 @@ def request_encounter_name(message)
   end
 end
 
-# Collect encounter data
 encounter_name = request_encounter_name('Encounter Name:')
 encounter_data = { name: encounter_name }
-
-# Create JSON file
-encounter_filename = sanitize_filename(encounter_name, extension: 'json')
-encounter_file_destination = "#{ENCOUNTERS_DIRECTORY}/#{encounter_filename}"
-File.write(encounter_file_destination, encounter_data.to_json)
-
-puts encounter_filename
+write_encounter_file(encounter_data)

--- a/manage_encounter.rb
+++ b/manage_encounter.rb
@@ -1,10 +1,10 @@
-# frozen_string_literal: true
-
 require 'active_support/core_ext/string'
 require 'json'
 
 SAFE_FILENAME_CHARACTERS = /[\w-]/.freeze
-ENCOUNTERS_DIRECTORY = 'data/encounters'
+ENCOUNTERS_DIRECTORY = 'data/encounters'.freeze
+
+@encounter_data = { monsters: [] }
 
 def write_encounter_file(encounter_data)
   encounter_name = encounter_data[:name]
@@ -12,7 +12,7 @@ def write_encounter_file(encounter_data)
   encounter_file_destination = "#{ENCOUNTERS_DIRECTORY}/#{encounter_filename}"
   File.write(encounter_file_destination, encounter_data.to_json)
 
-  puts "Printed encounter info to #{encounter_file_destination}"
+  puts "Printed encounter info to ./#{encounter_file_destination}"
 end
 
 def sanitize_filename(base_name, extension: nil)
@@ -21,7 +21,6 @@ def sanitize_filename(base_name, extension: nil)
 
   return unless sanitized_filename.present?
   sanitized_filename << ".#{extension}" if extension.present?
-  puts ''
 
   sanitized_filename
 end
@@ -31,7 +30,7 @@ def encounter_name_valid? encounter_name
   sanitized_name.present?
 end
 
-def request_encounter_name(message)
+def request_encounter_name(message = 'Encounter Name:')
   puts message
   encounter_name = gets.chomp
 
@@ -42,6 +41,45 @@ def request_encounter_name(message)
   end
 end
 
-encounter_name = request_encounter_name('Encounter Name:')
-encounter_data = { name: encounter_name }
-write_encounter_file(encounter_data)
+def request_monster_name
+  puts 'Monster Name:'
+  gets.chomp
+end
+
+def request_monster_race
+  previous_monster = @encounter_data[:monsters].last
+  default_race = previous_monster&.fetch(:race)
+
+  message = 'Monster Race:'
+  message << " (Default #{default_race})" if default_race.present?
+
+  puts message
+  gets.chomp
+end
+
+def request_monster_max_health(message = 'Max Health:')
+  puts message
+  max_health = gets.chomp
+  max_health = max_health.scan(/\d+/).first.to_i
+
+  if max_health.present?
+    max_health
+  else
+    request_monster_max_health('Invalid input. Please try again.')
+  end
+end
+
+def request_new_monster_data
+  monster_name = request_monster_name
+  monster_race = request_monster_race
+  monster_max_health = request_monster_max_health
+  { name: monster_name, race: monster_race, max_health: monster_max_health }
+end
+
+encounter_name = request_encounter_name
+@encounter_data[:name] = encounter_name
+
+monster_data = request_new_monster_data
+@encounter_data[:monsters] << monster_data
+
+write_encounter_file(@encounter_data)


### PR DESCRIPTION
# Overview
Process:
1. Script asks for encounter name
2. Script asks for monster name, race, and max health
3. Script prompts user to see if it should continue adding monsters (GOTO: 2)
4. Encounter name is down-cased, hyphenated, and sanitized for use as a file name
5. Encounter data is converted to JSON format and written to `data/encounters/` 

Features:
* User is re-prompted for encounter name if it would be blank after sensitization
* The previous race entered will be re-used if none is entered
